### PR TITLE
add check for impostor commits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@1b1aada464948af03b950897e5eb522f92603cc2 # github/codeql-action/init@v3
+      uses: github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@1b1aada464948af03b950897e5eb522f92603cc2 # github/codeql-action/autobuild@v3
+      uses: github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -81,6 +81,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1b1aada464948af03b950897e5eb522f92603cc2 # github/codeql-action/analyze@v3
+      uses: github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Commits in the forked repos can also be referenced as action hash on parent repository. Such commits are impostor commits. They pretend to be on the parent repository but actually aren't.

Added checks to see if any of the commits referenced are impostor commits.